### PR TITLE
Add region var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module "dcos-master-instances" {
 | aws_security_group_ids | Firewall IDs to use for these instances | list | - | yes |
 | aws_subnet_ids | Subnets to spawn the instances in. The module tries to distribute the instances | list | - | yes |
 | aws_user_data | User data to be used on these instances (cloud-init) | string | `` | no |
+| region | Specify the region to be used. | string | `` | no |
 | cluster_name | Cluster name all resources get named and tagged with | string | - | yes |
 | dcos_instance_os | Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `centos_7.4` | no |
 | hostname_format | Format the hostname inputs are index+1, region, cluster_name | string | `%[3]s-master%[1]d-%[2]s` | no |

--- a/main.tf
+++ b/main.tf
@@ -48,4 +48,3 @@ module "dcos-master-instances" {
   associate_public_ip_address = "${var.aws_associate_public_ip_address}"
   dcos_instance_os            = "${var.dcos_instance_os}"
 }
-

--- a/main.tf
+++ b/main.tf
@@ -32,10 +32,11 @@ module "dcos-master-instances" {
     aws = "aws"
   }
 
+  region                      = "${var.region}"
   cluster_name                = "${var.cluster_name}"
   hostname_format             = "${var.hostname_format}"
   num                         = "${var.num_masters}"
-  ami                = "${var.aws_ami}"
+  ami                         = "${var.aws_ami}"
   user_data                   = "${var.user_data}"
   instance_type               = "${var.aws_instance_type}"
   subnet_ids                  = ["${var.aws_subnet_ids}"]

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "Specify the region to be used"
+  default     = ""
+}
+
 variable "cluster_name" {
   description = "Cluster name all resources get named and tagged with"
 }


### PR DESCRIPTION
This will resolve an issue we are seeing with the Name Tag and hostname_format. Currently when the bootstrap module get passed to the lower level instance module it doesnt receive the region variable that is included in the hostname_format leaving the Name incomplete.