### PR TITLE
Feat: add extra volumes for masters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,10 +45,10 @@ module "dcos-master-instances" {
   key_name                    = var.aws_key_name
   root_volume_size            = var.aws_root_volume_size
   root_volume_type            = "gp2"
+  extra_volumes               = var.aws_extra_volumes
   tags                        = var.tags
   associate_public_ip_address = var.aws_associate_public_ip_address
   dcos_instance_os            = var.dcos_instance_os
   iam_instance_profile        = var.aws_iam_instance_profile
   name_prefix                 = var.name_prefix
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,11 @@ variable "aws_associate_public_ip_address" {
   default     = true
 }
 
+variable "aws_extra_volumes" {
+  description = "Extra volumes for each instance"
+  default     = []
+}
+
 variable "user_data" {
   description = "User data to be used on these instances (cloud-init)"
   default     = ""
@@ -72,4 +77,3 @@ variable "name_prefix" {
   description = "Name Prefix"
   default     = ""
 }
-


### PR DESCRIPTION
for whatever reason we simply did not allow adding extra volumes for master.

However this is quite beneficial for extra logging paritions or in heavy load environments for ZK. 